### PR TITLE
Improving client to use cursor

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -34,6 +34,7 @@ def retry_on_429(exc):
     """ Used to trigger retry on rate limit """
     return isinstance(exc, JupiterOneApiRetryError)
 
+
 class JupiterOneClient:
     """ Python client class for the JupiterOne GraphQL API """
     # pylint: disable=too-many-instance-attributes

--- a/jupiterone/constants.py
+++ b/jupiterone/constants.py
@@ -10,6 +10,24 @@ QUERY_V1 = """
   }
 """
 
+QUERY_V2 = """
+  query J1QL_v2($query: String!, $variables: JSON, $flags: QueryV1Flags, $includeDeleted: Boolean, $cursor: String) {
+    queryV1(
+      query: $query
+      variables: $variables
+      deferredResponse: FORCE
+      flags: $flags
+      includeDeleted: $includeDeleted
+      cursor: $cursor
+    ) {
+      type
+      url
+      cursor
+      __typename
+    }
+  }
+"""
+
 CREATE_ENTITY = """
   mutation CreateEntity(
     $entityKey: String!

--- a/jupiterone/constants.py
+++ b/jupiterone/constants.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 J1QL_SKIP_COUNT = 250
 J1QL_LIMIT_COUNT = 250
 
@@ -16,7 +14,7 @@ QUERY_V1 = """
   }
 """
 
-QUERY_V2 = """
+CURSOR_QUERY_V1 = """
   query J1QL_v2($query: String!, $variables: JSON, $flags: QueryV1Flags, $includeDeleted: Boolean, $cursor: String) {
     queryV1(
       query: $query

--- a/jupiterone/constants.py
+++ b/jupiterone/constants.py
@@ -1,5 +1,11 @@
+from enum import Enum
+
 J1QL_SKIP_COUNT = 250
 J1QL_LIMIT_COUNT = 250
+
+
+DEFERRED_RESULTS_IN_PROGRESS = 'IN_PROGRESS'
+DEFERRED_RESULTS_COMPLETED = 'COMPLETED'
 
 QUERY_V1 = """
   query J1QL($query: String!, $variables: JSON, $dryRun: Boolean, $includeDeleted: Boolean) {

--- a/jupiterone/errors.py
+++ b/jupiterone/errors.py
@@ -1,3 +1,4 @@
+from enum import Enum
 
 class JupiterOneClientError(Exception):
     """ Raised when error creating client """    
@@ -7,3 +8,6 @@ class JupiterOneApiRetryError(Exception):
 
 class JupiterOneApiError(Exception):
     """ Raised when API returns error response """
+
+class JupiterOneQueryTimeoutError(Exception):
+    """ Raised when query has timed out """

--- a/jupiterone/errors.py
+++ b/jupiterone/errors.py
@@ -1,4 +1,3 @@
-from enum import Enum
 
 class JupiterOneClientError(Exception):
     """ Raised when error creating client """    

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_reqs = [
 ]
 
 setup(name='jupiterone',
-      version='0.1.0',
+      version='0.2.0',
       description='A Python client for the JupiterOne API',
       license='MIT License',
       author='George Vauter',

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -87,7 +87,11 @@ def test_query_v1():
 
     j1 = JupiterOneClient(account='testAccount', token='testToken')
     query = "find Host with _id='1'"
-    response = j1.query_v1(query)
+    response = j1.query_v1(
+        query=query,
+        limit=250,
+        skip=0
+    )
 
     assert type(response) == dict
     assert len(response['data']) == 1
@@ -131,7 +135,11 @@ def test_tree_query_v1():
 
     j1 = JupiterOneClient(account='testAccount', token='testToken')
     query = "find Host with _id='1' return tree"
-    response = j1.query_v1(query)
+    response = j1.query_v1(
+        query=query,
+        limit=250,
+        skip=0
+    )
 
     assert type(response) == dict 
     assert 'edges' in response
@@ -139,4 +147,50 @@ def test_tree_query_v1():
     assert type(response['edges']) == list
     assert type(response['vertices']) == list
     assert response['vertices'][0]['id'] == '1'
-    
+
+def paginate_results_with_cursor():
+
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': {
+                'queryV1': {
+                    'type': 'list',
+                    'data': [
+                        {
+                            'id': '1',
+                            'entity': {
+                                '_rawDataHashes': '1',
+                                '_integrationDefinitionId': '1',
+                                '_integrationName': '1',
+                                '_beginOn': 1580482083079,
+                                'displayName': 'host1',
+                                '_class': ['Host'],
+                                '_scope': 'aws_instance',
+                                '_version': 1,
+                                '_integrationClass': 'CSP',
+                                '_accountId': 'testAccount',
+                                '_id': '1',
+                                '_key': 'key1',
+                                '_type': ['aws_instance'],
+                                '_deleted': False,
+                                '_integrationInstanceId': '1',
+                                '_integrationType': 'aws',
+                                '_source': 'integration-managed',
+                                '_createdOn': 1578093840019
+                            },
+                            'properties': {
+                                'id': 'host1',
+                                'active': True
+                            }
+                        }
+                    ],
+                    'cursor': 'cursor_value'
+                }
+            }
+        }
+
+        return (200, headers, json.dumps(response))

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -86,8 +86,6 @@ def build_deferred_query_results(response_code: int = 200, cursor: str = None, m
 
         pages.update(requests=1)
 
-        print('requestz', pages.get('requests'), cursor is not None, pages.get('requests') < max_pages)
-
         return (response_code, headers, json.dumps(response))
 
     return request_callback


### PR DESCRIPTION
### Description

The client currently uses `LIMIT` and `SKIP` conventions to paginate results. The latest convention uses a returned `cursor`  to paginate through result sets instead. This should increase the overall speed of pagination for large result sets.

I took a non-breaking approach to this update. If the user does not supply `limit` or `skip` parameters then the new `cursor` functionality will be used. 

Please let me know if I missed any requirements or expectations for this PR, thank you!

### Testing

[x] This change adds test coverage for new/changed/fixed functionality

I have added tests and modified existing tests to differentiate between the two potential code flows: pagination with `limit and skip` and `cursors`. This has also been verified against the real J1 backend.

### Checklist

- [ ] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`
