### PR TITLE
Use cursor pagination by default

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -133,15 +133,14 @@ class JupiterOneClient:
                 variables['cursor'] = cursor
 
             response = self._execute_query(query=CURSOR_QUERY_V1, variables=variables)
-            data = response['data']['queryV1']
+            data = response['data']['queryV1']['data']
 
             if 'vertices' in data and 'edges' in data:
                 return data
 
             results.extend(data)
 
-            if 'cursor' in response['data']['queryV1']:
-                print('cursor', response['data']['queryV1']['cursor'], len(data), len(results))
+            if 'cursor' in response['data']['queryV1'] and response['data']['queryV1']['cursor'] is not None:
                 cursor = response['data']['queryV1']['cursor']
             else:
                 break

--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -7,6 +7,7 @@ from typing import Dict, List
 
 import requests
 from retrying import retry
+from warnings import warn
 
 from jupiterone.errors import (
     JupiterOneClientError,
@@ -22,7 +23,8 @@ from jupiterone.constants import (
     DELETE_ENTITY,
     UPDATE_ENTITY,
     CREATE_RELATIONSHIP,
-    DELETE_RELATIONSHIP
+    DELETE_RELATIONSHIP,
+    CURSOR_QUERY_V1
 )
 
 def retry_on_429(exc):
@@ -105,25 +107,48 @@ class JupiterOneClient:
                     raise JupiterOneApiError(content.get('errors'))
                 return response.json()
 
-        elif response.status_code in [429, 500]:
+        elif response.status_code in [429, 503]:
             raise JupiterOneApiRetryError('JupiterOne API rate limit exceeded')
 
         else:
             content = json.loads(response._content)
             raise JupiterOneApiError('{}:{}'.format(response.status_code, content.get('error')))
 
-    def query_v1(self, query: str, **kwargs) -> Dict:
-        """ Performs a V1 graph query
+    def _cursor_query(self, query: str, cursor: str = None, include_deleted: bool = False) -> Dict:
+        """ Performs a V1 graph query using cursor pagination
             args:
                 query (str): Query text
-                skip (int):  Skip entity count
-                limit (int): Limit entity count
+                cursor (str): A pagination cursor for the initial query
                 include_deleted (bool): Include recently deleted entities in query/search
         """
-        skip: int = kwargs.pop('skip', J1QL_SKIP_COUNT)
-        limit: int = kwargs.pop('limit', J1QL_LIMIT_COUNT)
-        include_deleted: bool = kwargs.pop('include_deleted', False)
 
+        results: List = []
+        while True:
+            variables = {
+                'query': query,
+                'includeDeleted': include_deleted
+            }
+
+            if cursor is not None:
+                variables['cursor'] = cursor
+
+            response = self._execute_query(query=CURSOR_QUERY_V1, variables=variables)
+            data = response['data']['queryV1']
+
+            if 'vertices' in data and 'edges' in data:
+                return data
+
+            results.extend(data)
+
+            if 'cursor' in response['data']['queryV1']:
+                print('cursor', response['data']['queryV1']['cursor'], len(data), len(results))
+                cursor = response['data']['queryV1']['cursor']
+            else:
+                break
+
+        return {'data': results}
+
+    def _limit_and_skip_query(self, query: str, skip: int = J1QL_SKIP_COUNT, limit: int = J1QL_LIMIT_COUNT, include_deleted: bool = False) -> Dict:
         results: List = []
         page: int = 0
 
@@ -151,6 +176,36 @@ class JupiterOneClient:
             page += 1
 
         return {'data': results}
+
+    def query_v1(self, query: str, **kwargs) -> Dict:
+        """ Performs a V1 graph query
+            args:
+                query (str): Query text
+                skip (int):  Skip entity count
+                limit (int): Limit entity count
+                cursor (str): A pagination cursor for the initial query
+                include_deleted (bool): Include recently deleted entities in query/search
+        """
+        uses_limit_and_skip: bool = 'skip' in kwargs.keys() or 'limit' in kwargs.keys()
+        skip: int = kwargs.pop('skip', J1QL_SKIP_COUNT)
+        limit: int = kwargs.pop('limit', J1QL_LIMIT_COUNT)
+        include_deleted: bool = kwargs.pop('include_deleted', False)
+        cursor: str = kwargs.pop('cursor', None)
+
+        if uses_limit_and_skip:
+            warn('limit and skip pagination is no longer a recommended method for pagination. To read more about using cursors checkout the JupiterOne documentation: https://support.jupiterone.io/hc/en-us/articles/360022722094#entityandrelationshipqueries', DeprecationWarning, stacklevel=2)
+            return self._limit_and_skip_query(
+                query=query,
+                skip=skip,
+                limit=limit,
+                include_deleted=include_deleted
+            )
+        else:
+            return self._cursor_query(
+                query=query,
+                cursor=cursor,
+                include_deleted=include_deleted
+            )
 
     def create_entity(self, **kwargs) -> Dict:
         """ Creates an entity in graph.  It will also update an existing entity.

--- a/jupiterone/constants.py
+++ b/jupiterone/constants.py
@@ -6,6 +6,24 @@ QUERY_V1 = """
     queryV1(query: $query, variables: $variables, dryRun: $dryRun, includeDeleted: $includeDeleted) {
       type
       data
+      url
+    }
+  }
+"""
+
+CURSOR_QUERY_V1 = """
+  query J1QL_v2($query: String!, $variables: JSON, $flags: QueryV1Flags, $includeDeleted: Boolean, $cursor: String) {
+    queryV1(
+      query: $query
+      variables: $variables
+      flags: $flags
+      includeDeleted: $includeDeleted
+      cursor: $cursor
+    ) {
+      type
+      data
+      cursor
+      __typename
     }
   }
 """

--- a/jupiterone/constants.py
+++ b/jupiterone/constants.py
@@ -6,7 +6,6 @@ QUERY_V1 = """
     queryV1(query: $query, variables: $variables, dryRun: $dryRun, includeDeleted: $includeDeleted) {
       type
       data
-      url
     }
   }
 """
@@ -16,6 +15,7 @@ CURSOR_QUERY_V1 = """
     queryV1(
       query: $query
       variables: $variables
+      deferredResponse: DISABLED
       flags: $flags
       includeDeleted: $includeDeleted
       cursor: $cursor

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_reqs = [
 ]
 
 setup(name='jupiterone',
-      version='0.1.0',
+      version='0.2.0',
       description='A Python client for the JupiterOne API',
       license='MIT License',
       author='George Vauter',

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,60 +1,146 @@
 import json
 import pytest
 import responses
+from collections import Counter
 
 from jupiterone.client import JupiterOneClient
-from jupiterone.constants import QUERY_V1
+from jupiterone.constants import QUERY_V1, DEFERRED_RESULTS_COMPLETED
+from jupiterone.errors import JupiterOneApiError
 
-def request_callback(request):
-    headers = {
-        'Content-Type': 'application/json'
-    }
+API_ENDPOINT = 'https://api.us.jupiterone.io/graphql'
+STATE_FILE_ENDPOINT = 'https://api.us.jupiterone.io/state'
+RESULTS_ENDPOINT = 'https://api.us.jupiterone.io/results'
 
-    response = {
-        'data': {
-            'queryV1': {
-                'type': 'list',
-                'data': [
-                    {
-                        'id': '1',
-                        'entity': {
-                            '_rawDataHashes': '1',
-                            '_integrationDefinitionId': '1',
-                            '_integrationName': '1',
-                            '_beginOn': 1580482083079,
-                            'displayName': 'host1',
-                            '_class': ['Host'],
-                            '_scope': 'aws_instance',
-                            '_version': 1,
-                            '_integrationClass': 'CSP',
-                            '_accountId': 'testAccount',
-                            '_id': '1',
-                            '_key': 'key1',
-                            '_type': ['aws_instance'],
-                            '_deleted': False,
-                            '_integrationInstanceId': '1',
-                            '_integrationType': 'aws',
-                            '_source': 'integration-managed',
-                            '_createdOn': 1578093840019
-                        },
-                        'properties': {
-                            'id': 'host1',
-                            'active': True
-                        }
-                    }
-                ]
+def build_deferred_query_response(response_code: int = 200, url: str = STATE_FILE_ENDPOINT):
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': {
+                'queryV1': {
+                    'url': url
+                }
             }
         }
-    }
-    return (200, headers, json.dumps(response))
+        return (response_code, headers, json.dumps(response))
+    return request_callback
 
+
+def build_state_response(response_code: int = 200, status: str = DEFERRED_RESULTS_COMPLETED, url: str = RESULTS_ENDPOINT):
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'status': status,
+            'url': url
+        }
+        return (response_code, headers, json.dumps(response))
+    return request_callback
+
+def build_deferred_query_results(response_code: int = 200, cursor: str = None, max_pages: int = 1):
+    pages = Counter(requests=0)
+
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': [
+                {
+                    'id': '1',
+                    'entity': {
+                        '_rawDataHashes': '1',
+                        '_integrationDefinitionId': '1',
+                        '_integrationName': '1',
+                        '_beginOn': 1580482083079,
+                        'displayName': 'host1',
+                        '_class': ['Host'],
+                        '_scope': 'aws_instance',
+                        '_version': 1,
+                        '_integrationClass': 'CSP',
+                        '_accountId': 'testAccount',
+                        '_id': '1',
+                        '_key': 'key1',
+                        '_type': ['aws_instance'],
+                        '_deleted': False,
+                        '_integrationInstanceId': '1',
+                        '_integrationType': 'aws',
+                        '_source': 'integration-managed',
+                        '_createdOn': 1578093840019
+                    },
+                    'properties': {
+                        'id': 'host1',
+                        'active': True
+                    }
+                }
+            ]
+        }
+
+        if cursor is not None and pages.get('requests') < max_pages:
+            response['cursor'] = cursor
+
+        pages.update(requests=1)
+
+        return (response_code, headers, json.dumps(response))
+
+    return request_callback
+
+def build_results(response_code: int = 200):
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': {
+                'queryV1': {
+                    'type': 'list',
+                    'data': [
+                        {
+                            'id': '1',
+                            'entity': {
+                                '_rawDataHashes': '1',
+                                '_integrationDefinitionId': '1',
+                                '_integrationName': '1',
+                                '_beginOn': 1580482083079,
+                                'displayName': 'host1',
+                                '_class': ['Host'],
+                                '_scope': 'aws_instance',
+                                '_version': 1,
+                                '_integrationClass': 'CSP',
+                                '_accountId': 'testAccount',
+                                '_id': '1',
+                                '_key': 'key1',
+                                '_type': ['aws_instance'],
+                                '_deleted': False,
+                                '_integrationInstanceId': '1',
+                                '_integrationType': 'aws',
+                                '_source': 'integration-managed',
+                                '_createdOn': 1578093840019
+                            },
+                            'properties': {
+                                'id': 'host1',
+                                'active': True
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+        return (response_code, headers, json.dumps(response))
+    return request_callback
 
 @responses.activate
 def test_execute_query():
 
     responses.add_callback(
         responses.POST, 'https://api.us.jupiterone.io/graphql',
-        callback=request_callback,
+        callback=build_results(),
         content_type='application/json',
     )
 
@@ -73,30 +159,66 @@ def test_execute_query():
     assert 'queryV1' in response['data']
     assert len(response['data']['queryV1']['data']) == 1
     assert type(response['data']['queryV1']['data']) == list
-    assert response['data']['queryV1']['data'][0]['entity']['_id'] == '1' 
+    assert response['data']['queryV1']['data'][0]['entity']['_id'] == '1'
 
 
 @responses.activate
-def test_query_v1():
+def test_limit_skip_query_v1():
 
     responses.add_callback(
         responses.POST, 'https://api.us.jupiterone.io/graphql',
-        callback=request_callback,
+        callback=build_results(),
         content_type='application/json',
     )
 
     j1 = JupiterOneClient(account='testAccount', token='testToken')
     query = "find Host with _id='1'"
-    response = j1.query_v1(query)
+    response = j1.query_v1(
+        query=query,
+        limit=250,
+        skip=0
+    )
 
     assert type(response) == dict
     assert len(response['data']) == 1
     assert type(response['data']) == list
     assert response['data'][0]['entity']['_id'] == '1'
 
+@responses.activate
+def test_cursor_query_v1():
+
+    responses.add_callback(
+        responses.POST, API_ENDPOINT,
+        callback=build_deferred_query_response(url=STATE_FILE_ENDPOINT),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.GET, STATE_FILE_ENDPOINT,
+        callback=build_state_response(url=RESULTS_ENDPOINT),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.GET, RESULTS_ENDPOINT,
+        callback=build_deferred_query_results(cursor='cursor_value'),
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    query = "find Host with _id='1'"
+
+    response = j1.query_v1(
+        query=query,
+    )
+
+    assert type(response) == dict
+    assert len(response['data']) == 2
+    assert type(response['data']) == list
+    assert response['data'][0]['entity']['_id'] == '1'
 
 @responses.activate
-def test_tree_query_v1():
+def test_limit_skip_tree_query_v1():
 
     def request_callback(request):
         headers = {
@@ -131,12 +253,203 @@ def test_tree_query_v1():
 
     j1 = JupiterOneClient(account='testAccount', token='testToken')
     query = "find Host with _id='1' return tree"
-    response = j1.query_v1(query)
+    response = j1.query_v1(
+        query=query,
+        limit=250,
+        skip=0
+    )
 
-    assert type(response) == dict 
+    assert type(response) == dict
     assert 'edges' in response
     assert 'vertices' in response
     assert type(response['edges']) == list
     assert type(response['vertices']) == list
     assert response['vertices'][0]['id'] == '1'
-    
+
+@responses.activate
+def test_cursor_tree_query_v1():
+
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': {
+                'vertices': [
+                    {
+                        'id': '1',
+                        'entity': {},
+                        'properties': {}
+                    }
+                ],
+                'edges': []
+            }
+        }
+
+        return (200, headers, json.dumps(response))
+
+    responses.add_callback(
+        responses.POST, API_ENDPOINT,
+        callback=build_deferred_query_response(url=STATE_FILE_ENDPOINT),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.GET, STATE_FILE_ENDPOINT,
+        callback=build_state_response(url=RESULTS_ENDPOINT),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.GET, RESULTS_ENDPOINT,
+        callback=request_callback,
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    query = "find Host with _id='1' return tree"
+    response = j1.query_v1(
+        query=query
+    )
+
+    assert type(response) == dict
+    assert 'edges' in response
+    assert 'vertices' in response
+    assert type(response['edges']) == list
+    assert type(response['vertices']) == list
+    assert response['vertices'][0]['id'] == '1'
+
+@responses.activate
+def test_retry_on_limit_skip_query():
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=build_results(response_code=429),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=build_results(response_code=503),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=build_results(),
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    query = "find Host with _id='1'"
+    response = j1.query_v1(
+        query=query,
+        limit=250,
+        skip=0
+    )
+
+    assert type(response) == dict
+    assert len(response['data']) == 1
+    assert type(response['data']) == list
+    assert response['data'][0]['entity']['_id'] == '1'
+
+@responses.activate
+def test_retry_on_cursor_query():
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=build_results(response_code=429),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=build_results(response_code=503),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.POST, API_ENDPOINT,
+        callback=build_deferred_query_response(url=STATE_FILE_ENDPOINT),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.GET, STATE_FILE_ENDPOINT,
+        callback=build_state_response(response_code=503, url=RESULTS_ENDPOINT),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.GET, STATE_FILE_ENDPOINT,
+        callback=build_state_response(url=RESULTS_ENDPOINT),
+        content_type='application/json',
+    )
+
+    responses.add_callback(
+        responses.GET, RESULTS_ENDPOINT,
+        callback=build_deferred_query_results(),
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    query = "find Host with _id='1'"
+    response = j1.query_v1(
+        query=query
+    )
+
+    assert type(response) == dict
+    assert len(response['data']) == 1
+    assert type(response['data']) == list
+    assert response['data'][0]['entity']['_id'] == '1'
+
+@responses.activate
+def test_avoid_retry_on_limit_skip_query():
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=build_results(response_code=404),
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    query = "find Host with _id='1'"
+    with pytest.raises(JupiterOneApiError):
+        j1.query_v1(
+            query=query,
+            limit=250,
+            skip=0
+        )
+
+@responses.activate
+def test_avoid_retry_on_cursor_query():
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=build_results(response_code=404),
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    query = "find Host with _id='1'"
+    with pytest.raises(JupiterOneApiError):
+        j1.query_v1(
+            query=query,
+            limit=250,
+            skip=0
+        )
+
+@responses.activate
+def test_warn_limit_and_skip_deprecated():
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=build_results(),
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    query = "find Host with _id='1'"
+
+    with pytest.warns(DeprecationWarning):
+        j1.query_v1(
+            query=query,
+            limit=250,
+            skip=0
+        )

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -222,9 +222,7 @@ def test_cursor_tree_query_v1():
 
     j1 = JupiterOneClient(account='testAccount', token='testToken')
     query = "find Host with _id='1' return tree"
-    response = j1.query_v1(
-        query=query
-    )
+    response = j1.query_v1(query)
 
     assert type(response) == dict
     assert 'edges' in response


### PR DESCRIPTION
### Description

The client currently uses `LIMIT` and `SKIP` conventions to paginate results. The latest convention uses a returned `cursor`  to paginate through result sets instead. This should increase the overall speed of pagination for large result sets.

I took a non-breaking approach to this update. If the user does not supply `limit` or `skip` parameters then the new `cursor` functionality will be used. 

Please let me know if I missed any requirements or expectations for this PR, thank you!

### Testing

[x] This change adds test coverage for new/changed/fixed functionality

I have added tests and modified existing tests to differentiate between the two potential code flows: pagination with `limit and skip` and `cursors`. This has also been verified against the real J1 backend.

### Checklist

- [x] All active GitHub checks for tests, formatting, and security are passing
- [x] The correct base branch is being used, if not `master`