### PR TITLE
Improve response error handling - Fixes auth0 Issue 12

### DIFF
--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -117,8 +117,9 @@ class JupiterOneClient:
             content = response._content
             if isinstance(content, (bytes, bytearray)):
                 content = content.decode("utf-8")
-            if 'application/json' in response.headers.get('Content-Type', 'application/json') and '"error":' in content:
-                content = json.loads(content).get('error')
+            if 'application/json' in response.headers.get('Content-Type', 'text/plain'):
+                data = json.loads(content)
+                content = data.get('error', data.get('errors', content))
             raise JupiterOneApiError('{}:{}'.format(response.status_code, content))
 
     def _cursor_query(self, query: str, cursor: str = None, include_deleted: bool = False) -> Dict:


### PR DESCRIPTION
### Description

The current handling of API response error(s) in `JupiterOneClient._execute_query`, besides the status codes 429 and 503, expects the response content to be JSON, but that isn't always the case, such as 401 Unauthorized. This caused a JSONDecodeError to be thrown instead which obfuscated the actual error in the API response in which the content type was not application/json.

Added handling of 401 and other responses that aren't JSON.
Added tests for the new error handling.


### References

[auth0#12](https://github.com/auth0/jupiterone-python-sdk/issues/12)


### Testing

I updated the pytests in test_client.py, but manual tests just require using a bogus account or token.

- [X] This change adds test coverage for new/changed/fixed functionality


### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [X] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not `master`
