### PR TITLE
Add parameter methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,3 +102,42 @@ j1.create_relationship(
 ```python
 j1.delete_relationship(relationship_id='<id-of-relationship-to-delete>')
 ```
+
+##### Create a parameter, or modify an existing parameter
+
+```python
+set_status = j1.set_parameter(
+    name='name_of_parameter', # If 'name_of_parameter' already exists, the value is modified
+    value='value_to_be_stored', # Can be a string, number, boolean, or list
+    secret=(True|False) # Optional, defaults to False
+)
+```
+
+##### Get a stored parameter
+
+```python
+parameter = j1.get_parameter(
+    name='name_of_parameter'
+)
+
+print(parameter) # Returns a dictionary of format {'name': $parameterName, 'value': $parameterValue, 'secret': $isParameterSecret, 'lastUpdatedOn': $lastUpdateTimestamp}
+print(parameter['value']) # Returns the stored value for that parameter. If parameter['seceret'] = True, then parameter['value'] will always return '[REDACTED]' when accessed by API
+```
+
+##### Get all stored parameters
+
+```python
+parameterList = j1.get_parameter_list()
+
+print(parameterList) # Returns a dictionary of format {'parameters': parameter_list[]}
+print(parameterList[0]) # Returns the first parameter as a dictionary
+print(parameterList[0]['value']) # Returns the stored value of the first parameter
+```
+
+##### Delete a stored parameter
+
+```python
+j1.delete_parameter(
+    name='name_of_parameter'
+)
+```

--- a/README.md
+++ b/README.md
@@ -115,13 +115,15 @@ set_status = j1.set_parameter(
 
 ##### Get a stored parameter
 
+Parameters are stored as a dictionary of the format `{'name': $parameterName, 'value': $parameterValue, 'secret': $isParameterSecret, 'lastUpdatedOn': $lastUpdateTimestamp}`
+
 ```python
 parameter = j1.get_parameter(
     name='name_of_parameter'
 )
 
-print(parameter) # Returns a dictionary of format {'name': $parameterName, 'value': $parameterValue, 'secret': $isParameterSecret, 'lastUpdatedOn': $lastUpdateTimestamp}
-print(parameter['value']) # Returns the stored value for that parameter. If parameter['seceret'] = True, then parameter['value'] will always return '[REDACTED]' when accessed by API
+print(parameter)
+print(parameter['value']) # If parameter['secret'] = True, then parameter['value'] will return '[REDACTED]'
 ```
 
 ##### Get all stored parameters

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ set_status = j1.set_parameter(
 
 ##### Get a stored parameter
 
-Parameters are stored as a dictionary of the format `{'name': $parameterName, 'value': $parameterValue, 'secret': $isParameterSecret, 'lastUpdatedOn': $lastUpdateTimestamp}`
+Parameters are stored as a dictionary in the format `{'name': $parameterName, 'value': $parameterValue, 'secret': $isParameterSecret, 'lastUpdatedOn': $lastUpdateTimestamp}`
 
 ```python
 parameter = j1.get_parameter(
@@ -123,7 +123,7 @@ parameter = j1.get_parameter(
 )
 
 print(parameter)
-print(parameter['value']) # If parameter['secret'] = True, then parameter['value'] will return '[REDACTED]'
+print(parameter['value']) # If parameter['secret'] = True, then parameter['value'] will be '[REDACTED]'
 ```
 
 ##### Get all stored parameters
@@ -131,7 +131,7 @@ print(parameter['value']) # If parameter['secret'] = True, then parameter['value
 ```python
 parameterList = j1.get_parameter_list()
 
-print(parameterList) # Returns a dictionary of format {'parameters': parameter_list[]}
+print(parameterList) # Returns a dictionary in format {'parameters': list_of_parameters}
 print(parameterList[0]) # Returns the first parameter as a dictionary
 print(parameterList[0]['value']) # Returns the stored value of the first parameter
 ```

--- a/jupiterone/client.py
+++ b/jupiterone/client.py
@@ -365,7 +365,7 @@ class JupiterOneClient:
             else:
                 break
 
-        return response['data']['parameter']
+        return {'parameters': parameter_list}
 
     def set_parameter(self, name: str = None, value: str | int | float | bool | list = None, secret: bool = False):
         """ Create/update a remote parameter.

--- a/jupiterone/constants.py
+++ b/jupiterone/constants.py
@@ -135,3 +135,47 @@ DELETE_RELATIONSHIP = """
     }
   }
 """
+
+GET_PARAMETER = """
+  query Query($name: String!) {
+    parameter (name: $name) {
+      name
+      value
+      secret
+      lastUpdatedOn
+    }
+  }
+"""
+
+GET_PARAMETER_LIST = """
+  query Query($limit: Int, $cursor: String!) {
+    parameterList (limit: $limit, cursor: $cursor) {
+      items {
+        name
+        value
+        secret
+        lastUpdatedOn
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+"""
+
+SET_PARAMETER = """
+  mutation Mutation($name: String!, $value: ParameterValue!, $secret: Boolean) {
+    setParameter (name: $name, value: $value, secret: $secret) {
+      success
+    }
+  }
+"""
+
+DELETE_PARAMETER = """
+  mutation Mutation($name: String!) {
+    deleteParameter (name: $name) {
+      success
+    }
+  }
+"""

--- a/tests/test_delete_parameter.py
+++ b/tests/test_delete_parameter.py
@@ -14,7 +14,7 @@ def test_delete_parameter():
 
         response = {
             'data': {
-                'setParameter': {
+                'deleteParameter': {
                     'success': True
                 }
             }

--- a/tests/test_delete_parameter.py
+++ b/tests/test_delete_parameter.py
@@ -1,0 +1,35 @@
+import json
+import responses
+
+from jupiterone.client import JupiterOneClient
+
+
+@responses.activate
+def test_delete_parameter():
+
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': {
+                'setParameter': {
+                    'success': True
+                }
+            }
+        }
+        return (200, headers, json.dumps(response))
+    
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=request_callback,
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    response = j1.delete_parameter('testKey')
+
+    assert type(response) == dict
+    assert type(response['success']) == bool
+    assert response['success'] == True

--- a/tests/test_get_parameter.py
+++ b/tests/test_get_parameter.py
@@ -1,0 +1,44 @@
+import json
+import responses
+
+from jupiterone.client import JupiterOneClient
+
+
+@responses.activate
+def test_get_parameter():
+
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': {
+                'parameter': {
+                    'name': 'name',
+                    'value': 1,
+                    'secret': False,
+                    'lastUpdatedOn': 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+                }
+            }
+        }
+        return (200, headers, json.dumps(response))
+    
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=request_callback,
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    response = j1.get_parameter('testKey')
+
+    assert type(response) == dict
+    assert type(response['name']) == str
+    assert type(response['value']) in [str, int, float, bool, list]
+    assert type(response['secret']) == bool
+    assert type(response['lastUpdatedOn']) == str
+    assert response['name'] == 'name'
+    assert response['value'] == 1
+    assert response['secret'] == False
+    assert response['lastUpdatedOn'] == 'YYYY-MM-DDTHH:mm:ss.SSSZ'

--- a/tests/test_get_parameter_list.py
+++ b/tests/test_get_parameter_list.py
@@ -1,0 +1,67 @@
+import json
+import responses
+
+from jupiterone.client import JupiterOneClient
+
+
+@responses.activate
+def test_get_parameter_list():
+
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': {
+                'parameterList': {
+                    'items': [
+                        {
+                            'name': 'name1',
+                            'value': 1,
+                            'secret': False,
+                            'lastUpdatedOn': 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+                        },
+                        {
+                            'name': 'name2',
+                            'value': '[REDACTED]',
+                            'secret': True,
+                            'lastUpdatedOn': 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+                        }
+                    ],
+                    'pageInfo': {
+                        'endCursor': None,
+                        'hasNextPage': False
+                    }
+                }
+            }
+        }
+        return (200, headers, json.dumps(response))
+    
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=request_callback,
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    response = j1.get_parameter_list()
+
+    assert type(response) == dict
+    assert type(response['parameters']) == list
+    assert type(response['parameters'][0]['name']) == str
+    assert type(response['parameters'][0]['value']) in [str, int, float, bool, list]
+    assert type(response['parameters'][0]['secret']) == bool
+    assert type(response['parameters'][0]['lastUpdatedOn']) == str
+    assert response['parameters'][0]['name'] == 'name1'
+    assert response['parameters'][0]['value'] == 1
+    assert response['parameters'][0]['secret'] == False
+    assert response['parameters'][0]['lastUpdatedOn'] == 'YYYY-MM-DDTHH:mm:ss.SSSZ'
+    assert type(response['parameters'][1]['name']) == str
+    assert type(response['parameters'][1]['value']) in [str, int, float, bool, list]
+    assert type(response['parameters'][1]['secret']) == bool
+    assert type(response['parameters'][1]['lastUpdatedOn']) == str
+    assert response['parameters'][1]['name'] == 'name2'
+    assert response['parameters'][1]['value'] == '[REDACTED]'
+    assert response['parameters'][1]['secret'] == True
+    assert response['parameters'][1]['lastUpdatedOn'] == 'YYYY-MM-DDTHH:mm:ss.SSSZ'

--- a/tests/test_set_parameter.py
+++ b/tests/test_set_parameter.py
@@ -1,0 +1,35 @@
+import json
+import responses
+
+from jupiterone.client import JupiterOneClient
+
+
+@responses.activate
+def test_set_parameter():
+
+    def request_callback(request):
+        headers = {
+            'Content-Type': 'application/json'
+        }
+
+        response = {
+            'data': {
+                'setParameter': {
+                    'success': True
+                }
+            }
+        }
+        return (200, headers, json.dumps(response))
+    
+    responses.add_callback(
+        responses.POST, 'https://api.us.jupiterone.io/graphql',
+        callback=request_callback,
+        content_type='application/json',
+    )
+
+    j1 = JupiterOneClient(account='testAccount', token='testToken')
+    response = j1.set_parameter('testKey', 'testValue')
+
+    assert type(response) == dict
+    assert type(response['success']) == bool
+    assert response['success'] == True


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md). Please see the [contributing guidelines](https://github.com/auth0/.github/blob/master/CONTRIBUTING.md) for how to create and submit a high-quality PR for this repo.

### Description
Add methods to `JupiterOneClient` that enable reading, creating, modifying, and deleting parameters within the JupiterOne tenant as described at https://docs.jupiterone.io/features/admin/parameters#usage-api-operations-and-queries

Parameters can be used in JupiterOne queries by replacing static values with `${param.name_of_parameter}`, which JupiterOne provides an example of [here](https://docs.jupiterone.io/features/admin/parameters#usage-api-operations-and-queries).

These parameters can also be used in queries for both Dashboards (for point-in-time statuses) and Questions (for historic lookbacks) based on values that are subject to change. For example, a parameter "latest_OS_version" can be set and changed to show how many devices are up-to-date on OS patches.

### References
Resolves https://github.com/auth0/jupiterone-python-sdk/issues/17

### Testing
Pytest test cases have been added for each new method.

- [X] This change adds test coverage for new/changed/fixed functionality

### Checklist

- [X] I have added documentation for new/changed functionality in this PR or in auth0.com/docs
- [x] All active GitHub checks for tests, formatting, and security are passing
- [X] The correct base branch is being used, if not the default branch
